### PR TITLE
Fix extraction of OpenStack auth vars

### DIFF
--- a/{{cookiecutter.cloud_shortname}}-config/ansible/group_vars/all/openstack
+++ b/{{cookiecutter.cloud_shortname}}-config/ansible/group_vars/all/openstack
@@ -10,7 +10,7 @@ openstack_auth_type: "password"
 # compatible with the 'auth' argument of most 'os_*' Ansible modules.
 # By default we pull these from the environment of the shell executing Ansible.
 openstack_auth:
-  project_domain_name: "{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') }}"
+  project_domain_name: "{{ lookup('env', 'OS_PROJECT_DOMAIN_ID') }}"
   user_domain_name: "{{ lookup('env', 'OS_USER_DOMAIN_NAME') }}"
   project_name: "{{ lookup('env', 'OS_PROJECT_NAME') }}"
   username: "{{ lookup('env', 'OS_USERNAME') }}"


### PR DESCRIPTION
Appears we want OS_PROJECT_DOMAIN_ID not OS_PROJECT_DOMAIN_NAME.

Tested using Keystone v3 rc files from two recent deployments.