### PR TITLE
Set user and project domain IDs if present

### DIFF
--- a/{{cookiecutter.cloud_shortname}}-config/ansible/group_vars/all/openstack
+++ b/{{cookiecutter.cloud_shortname}}-config/ansible/group_vars/all/openstack
@@ -10,6 +10,8 @@ openstack_auth_type: "password"
 # compatible with the 'auth' argument of most 'os_*' Ansible modules.
 # By default we pull these from the environment of the shell executing Ansible.
 openstack_auth:
+  project_domain_id: "{{ lookup('env', 'OS_PROJECT_DOMAIN_ID') }}"
+  user_domain_id: "{{ lookup('env', 'OS_USER_DOMAIN_ID') }}"
   project_domain_name: "{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') }}"
   user_domain_name: "{{ lookup('env', 'OS_USER_DOMAIN_NAME') }}"
   project_name: "{{ lookup('env', 'OS_PROJECT_NAME') }}"


### PR DESCRIPTION
Horizon generates openrc.sh files containing only `OS_USER_DOMAIN_NAME`
and `OS_PROJECT_DOMAIN_ID`. Attempting to use these openrc.sh files
results in:

    keystoneauth1.exceptions.http.BadRequest: Expecting to find domain in project

Closes #5.