### PR TITLE
Set project_id variable

### DIFF
--- a/{{cookiecutter.cloud_shortname}}-config/ansible/group_vars/all/openstack
+++ b/{{cookiecutter.cloud_shortname}}-config/ansible/group_vars/all/openstack
@@ -14,6 +14,7 @@ openstack_auth:
   user_domain_id: "{{ lookup('env', 'OS_USER_DOMAIN_ID') }}"
   project_domain_name: "{{ lookup('env', 'OS_PROJECT_DOMAIN_NAME') }}"
   user_domain_name: "{{ lookup('env', 'OS_USER_DOMAIN_NAME') }}"
+  project_id: "{{ lookup('env', 'OS_PROJECT_ID') }}"
   project_name: "{{ lookup('env', 'OS_PROJECT_NAME') }}"
   username: "{{ lookup('env', 'OS_USERNAME') }}"
   password: "{{ lookup('env', 'OS_PASSWORD') }}"


### PR DESCRIPTION
If unset and a clouds.yaml file is present with a cloud definition
including a project_id, it will be used and may cause requests to fail
if not matching a valid project for the user.

This works fine if OS_PROJECT_ID is not defined in the environment.

Closes #12.