### PR TITLE
Use an implicit localhost entry in the inventory

### DIFF
--- a/{{cookiecutter.cloud_shortname}}-config/ansible/inventory
+++ b/{{cookiecutter.cloud_shortname}}-config/ansible/inventory
@@ -1,1 +1,3 @@
-localhost ansible_host=127.0.0.1
+# Use an implicit localhost entry in the inventory.
+# This helps with python interpreter handling when working with virtualenvs
+# and local connections.


### PR DESCRIPTION
This helps with python interpreter handling when working with virtualenvs
and local connections.