### PR TITLE
Use correct parameter for network floating IP quota

### DIFF
--- a/{{cookiecutter.cloud_shortname}}-config/etc/{{cookiecutter.cloud_shortname}}-config/{{cookiecutter.cloud_shortname}}-config.yml
+++ b/{{cookiecutter.cloud_shortname}}-config/etc/{{cookiecutter.cloud_shortname}}-config/{{cookiecutter.cloud_shortname}}-config.yml
@@ -51,7 +51,7 @@
   backups: -1
   cores: -1
   fixed_ips: -1
-  floating_ips: -1
+  floatingip: -1
   gigabytes: -1
   injected_file_size: -1
   injected_files: -1


### PR DESCRIPTION
The floating_ips parameters refers to the floating IP quota in Nova.