### PR TITLE
Use openstack.cloud collection and bump to Ansible 2.10

### DIFF
--- a/{{cookiecutter.cloud_shortname}}-config/.gitignore
+++ b/{{cookiecutter.cloud_shortname}}-config/.gitignore
@@ -107,3 +107,5 @@ venv.bak/
 ansible/*.retry
 # Galaxy roles.
 ansible/roles/*\.*/
+# Galaxy collections
+ansible/collections/**/

--- a/{{cookiecutter.cloud_shortname}}-config/README.rst
+++ b/{{cookiecutter.cloud_shortname}}-config/README.rst
@@ -26,12 +26,16 @@ packages. For example:
    $ pip install -U pip
    $ pip install -r requirements.txt
 
-Install Ansible role dependencies from Ansible Galaxy:
+Install Ansible role and collection dependencies from Ansible Galaxy:
 
 .. code-block::
 
-   $ ansible-galaxy install \
-       -p ansible/roles \
+   $ ansible-galaxy role install \
+        -p ansible/roles \
+        -r requirements.yml
+
+   $ ansible-galaxy collection install \
+       -p ansible/collections \
        -r requirements.yml
 
 Usage

--- a/{{cookiecutter.cloud_shortname}}-config/requirements.txt
+++ b/{{cookiecutter.cloud_shortname}}-config/requirements.txt
@@ -1,2 +1,2 @@
-# Use Ansible 2.9 which supports setting MTU of Neutron networks
-ansible>=2.9.0,<2.10.0
+# Use Ansible 2.10 for better collections handling
+ansible>=2.10.0,<2.11.0

--- a/{{cookiecutter.cloud_shortname}}-config/requirements.yml
+++ b/{{cookiecutter.cloud_shortname}}-config/requirements.yml
@@ -1,7 +1,11 @@
 ---
-- src: stackhpc.os-flavors
-- src: stackhpc.os-images
-- src: stackhpc.os-networks
-- src: stackhpc.os-projects
-- src: stackhpc.os_host_aggregates
-- src: stackhpc.os-container-clusters
+roles:
+  - name: stackhpc.os-flavors
+  - name: stackhpc.os-images
+  - name: stackhpc.os-networks
+  - name: stackhpc.os-projects
+  - name: stackhpc.os_host_aggregates
+  - name: stackhpc.os-container-clusters
+
+collections:
+  - name: openstack.cloud


### PR DESCRIPTION
Use openstack.cloud collection as it has multiple new modules and bug fixes to them. Bump to Ansible 2.10 for better collections handling.