### PR TITLE
add ansible_connection=local to prevent use of ssh for localhost

### DIFF
--- a/{{cookiecutter.cloud_shortname}}-config/ansible/inventory
+++ b/{{cookiecutter.cloud_shortname}}-config/ansible/inventory
@@ -1,1 +1,1 @@
-localhost ansible_host=127.0.0.1
+localhost ansible_host=127.0.0.1 ansible_connection=local


### PR DESCRIPTION
useful in CI for example when ssh is not enabled in docker containers.